### PR TITLE
🚧WIP: add the ability to turn a USB port on and off

### DIFF
--- a/helpers/lightbox.lua
+++ b/helpers/lightbox.lua
@@ -1,0 +1,92 @@
+local logger = hs.logger.new("lightbox")
+local lightmenu = hs.menubar.new()
+
+-- these two variables are currently hardcoded to my
+-- Apple Keyboard's USB id to manage its left USB port
+local vendor_product_id = "1452:591"
+local usb_command = "uhubctl --vendor 05ac --ports 1 "
+
+function lightboxSet(lit)
+    if lit then
+        local output, status, type, rc = hs.execute(usb_command .. "--action on", true)
+        logger.d(output)
+        lightmenu:setTitle("💡")
+        lightmenu:setTooltip("The light is lit.")
+        logger.i("turn on the light")
+    else
+        local output, status, type, rc = hs.execute(usb_command .. "--action off", true)
+        logger.d(output)
+        lightmenu:setTitle("⚫️")
+        lightmenu:setTooltip("The light is off.")
+        logger.i("turn off the light")
+    end
+end
+
+function lightboxGet()
+    local output, status, type, rc = hs.execute(usb_command .. ' | grep Port | grep power', true)
+    return rc == 0
+end
+
+function lightboxToggle()
+    local current = lightboxGet()
+    if (current == nil) then
+        return nil
+    end
+    lightboxSet(not current)
+    return lightboxGet()
+end
+
+function isLightboxUSB(vendorID, productID)
+    return vendorID .. ':' .. productID == vendor_product_id
+end
+
+function pluggedIn()
+    for _, dev in ipairs(hs.usb.attachedDevices()) do
+        if isLightboxUSB(dev["vendorID"], dev["productID"]) then
+            return true
+        end
+    end
+
+    return false
+end
+
+function usbDeviceCallback(data)
+    if isLightboxUSB(data["vendorID"], data["productID"]) then
+        if data["eventType"] == "added" then
+            logger.i("Apple Keyboard hub just plugged in. Turning off the light.")
+            lightmenu:returnToMenuBar()
+            lightboxSet(false)
+        elseif data["eventType"] == "removed" then
+            logger.i("Apply Keyboard hub unplugged. Removing menubar icon.")
+            lightmenu:removeFromMenuBar()
+        end
+    end
+end
+
+lightmenu:setTitle("❓")
+lightmenu:setClickCallback(lightboxToggle)
+
+if pluggedIn() then
+    lightmenu:returnToMenuBar()
+else
+    lightmenu:removeFromMenuBar()
+end
+
+usbWatcher = hs.usb.watcher.new(usbDeviceCallback)
+usbWatcher:start()
+
+local M = {}
+
+function M.on()
+  lightboxSet(true)
+end
+
+function M.off()
+  lightboxSet(false)
+end
+
+function M.toggle()
+  lightboxToggle()
+end
+
+return M

--- a/helpers/zoom_detect.lua
+++ b/helpers/zoom_detect.lua
@@ -44,7 +44,9 @@ function isInMeeting()
 end
 
 function meeting_menu_is_present(app)
-    return app:getMenuItems()[2]["AXTitle"] == "Meeting"
+    menu_items = app:getMenuItems()
+    if menu_items == nil then return false end
+    return menu_items[2]["AXTitle"] == "Meeting"
 end
 
 function meetingCheck()


### PR DESCRIPTION
LightBox currently has very little to do with actual lights. The code manages the on/off state of a designated USB port and shows that on/off status in an icon added to the Apple menubar. Clicking the icon will also toggle the on/off state. Super janky tray app!

Also kinda revamped how the zoom detection works:

* changed the in-meeting detection to look in the Zoom app's pull down menus; if "Meeting" in present as a pull-down, you're in a meeting. Needed to do this because the window title detection would miss when I was screen sharing.
* used a Hammerspoon application watcher to check for starting/stopping and focus/unfocus of the Zoom application to decide whether to run the timer that checks for in-meeting status. The timer now stops polling for whether you're in a meeting if Zoom isn't running.

Some ideas I have for this or for the future:

- [ ] setup the `zoom_detect` piece to only be responsible for detecting zoom meetings and emit something that other things can subscribe to, maybe with the [hs.watchable](http://www.hammerspoon.org/docs/hs.watchable.html) evented key/value?
- [ ] separate the Slack updating to a stand-alone module that could be subscribed in `init.lua` to take action on a `zoom_detect` event
- [ ] make the lightbox module event-driven to be subscribed in `init.lua`
- [ ] some way to configure these things (e.g. the USB device id for lightbox) without editing the code