### PR TITLE
Add presence update to Lua script, add do not disturb shell script and Lua function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A simple shell script to update your status in slack from the command line, base
 
 Copy `slack_status.sh` to somewhere in your path.
 
+## TODO
+
+- Prompt user if if they want `slack_status.sh`, `awayback.sh`, `dnd.sh`, or all three.
+- Allow config to `ln -s` shell scripts to `/usr/local/bin`
+- Allow config to `ln -s` Lua script to `~/.hammerspoon`
+
 ## Setup
 
 Before you can use this, you need to add the status updater as a new slack app. To do this:
@@ -16,8 +22,10 @@ Before you can use this, you need to add the status updater as a new slack app. 
 * This will bring you to the app configuration section, choose "OAuth and Permissions"  from the sidebar on the left under the "Features" section.
 * Scroll down until you see "User token scopes" and click "Add an OAuth scope"
 * Type in `users.profile:write` and select it from the menu.
-* If you want to use the `awayback.sh` script that's also in this
-  repository, add the `users:write` scope as well.
+* If you want to use the `awayback.sh` script that's also in this repository, add the `users:write` scope as well.
+  * If not, comment out usages of `update_presence` function in `zoom_detect.lua`.
+* If you want to use the `dnd.sh` script that's also in this repository, add the `dnd:write` scope as well.
+  * If not, comment out usages of `update_dnd` function in `zoom_detect.lua`.
 * Scroll back to the top and click the "Install App to Workspace" button.
 * You will be brought to a screen asking you to allow the app access. Click "Allow"
 * You will be taken back to a screen containing an access token starting with `xoxp-`. Click the "Copy" button to copy this to the clipboard.
@@ -59,9 +67,9 @@ To install it:
 * Install and set up the slack_status.sh script (make sure it's in your path)
 * Ensure there is a 'zoom' preset (one is created by default during setup)
 * Install hammerspoon (brew cask install hammerspoon) if you don't have it already.
-* Copy the `zoom_detect.lua` file to ~/.hammerspoon/
-* Add the following line to ~/.hammerspoon/init.lua:
-  `local zoom_detect = require("zoom_detect")`
+* Copy the `zoom_detect.lua` file to `~/.hammerspoon/`
+* Add the following line to `~/.hammerspoon/init.lua`:
+  * `local zoom_detect = require("zoom_detect")`
 
 ### Alfred workflow
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A simple shell script to update your status in slack from the command line, based on presets you provide in a configuration file.
 
+This is a fork that adds support for presence/DND instead of just status (well, manual presence changing was previously supported, but not with the Zoom integration). The original author's blog post: https://ruk.ca/content/automatically-setting-my-slack-status-when-im-zoom-meeting
+
+# A note on security
+
+This app requires you to trust:
+- [Hammerspoon](https://www.hammerspoon.org/)
+- The shell scripts in this repo.
+
+Everything else is official Slack APIs with minimal token access (one for each of "status", "presence", "dnd", see below for details).
+
 ## Installation
 
 Copy `slack_status.sh` to somewhere in your path.

--- a/dnd.sh
+++ b/dnd.sh
@@ -28,6 +28,8 @@ if [[ $STATE != "on" && $STATE != "off" ]]; then
     exit 1
 fi
 
+# The Slack API doesn't seem to let you set an indefinite DND, so you have to provide a time in minutes
+# TODO: Allow users to configure this, but for now 60 minutes seems fine
 if [[ $STATE == "on" ]]; then
     STATE="60"
 else

--- a/dnd.sh
+++ b/dnd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+CONFIG_FILE="$HOME/.slack_status.conf"
+
+# Colors
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+reset=$(tput sgr0)
+
+if [[ -f "$CONFIG_FILE" ]]; then
+    . "$CONFIG_FILE"
+else
+    echo "${green}Slack status updater${reset}"
+    echo "${green}====================${reset}"
+    echo
+    echo "Toggle your slack do not disturb on/off"
+    echo
+    echo "No configuration file found at $CONFIG_FILE"
+    exit 1
+fi
+
+STATE="$1"
+
+if [[ $STATE != "on" && $STATE != "off" ]]; then
+    echo "Usage: $0 [on|off]"
+    echo
+    echo "Set your slack do not distrubn on or off"
+    exit 1
+fi
+
+if [[ $STATE == "on" ]]; then
+    STATE="60"
+else
+    STATE="0"
+fi
+
+curl -s --data token="$TOKEN" \
+    --data num_minutes="$STATE" \
+    https://slack.com/api/dnd.setSnooze | \
+    grep -Eq '"ok": ?true' && \
+        echo "${green}Do not distrub updated ok${reset}" || \
+        echo "${red}There was a problem toggling do not distrub${reset}"

--- a/helpers/zoom_detect.lua
+++ b/helpers/zoom_detect.lua
@@ -14,10 +14,18 @@
 --   accessibility is enabled
 
 -- Configuration
-check_interval=20 -- How often to check if you're in zoom, in seconds
+check_interval=30 -- How often to check if you're in zoom, in seconds
 
 function update_status(status)
     task = hs.execute("slack_status.sh " .. status, true)
+end
+
+function update_presence(presence)
+    task = hs.execute("awayback.sh " .. presence, true)
+end
+
+function update_dnd(on_or_off)
+    task = hs.execute("dnd.sh " .. on_or_off, true)
 end
 
 function in_zoom_meeting()
@@ -39,12 +47,16 @@ zoomTimer = hs.timer.doEvery(check_interval, function()
             inzoom = true
             hs.notify.show("Started zoom meeting", "Updating slack status", "")
             update_status("zoom")
+            update_presence("away")
+            update_dnd("on")
         end
     else
         if inzoom == true then
             inzoom = false
             hs.notify.show("Left zoom meeting", "Updating slack status", "")
             update_status("none")
+            update_presence("back")
+            update_dnd("off")
         end
     end
 end)


### PR DESCRIPTION
As is this would cause failures if people set up the Hammerspoon Zoom script if they don't want the presence/DND tokens in Slack, but it works for my use case. Feel free to suggest edits or add commits if you'd like. 🙂 

If this doesn't get merged, no worries. I just figured I'd contribute back!