### PR TITLE
Support lowercase menubar name for newer Zoom versions

### DIFF
--- a/helpers/zoom_detect.lua
+++ b/helpers/zoom_detect.lua
@@ -23,7 +23,7 @@ end
 function in_zoom_meeting()
     local a = hs.application.find("zoom.us")
     if a ~= nil then
-        m = a:findMenuItem("Join Meeting...")
+        m = a:findMenuItem("Join Meeting...") or a:findMenuItem("Join meeting...")
         -- Start meeting menu item exists and is disabled
         return m ~= nil and not m["enabled"]
     else


### PR DESCRIPTION
Zoom recently released a new version which changed the casing on the menu bar option name for joining meetings.  This change allows for both the old and new menu bar names.